### PR TITLE
fix: update package.json to resolve typescript errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"README.md"
 	],
 	"scripts": {
-		"generate-typedocs": "typedoc --includeDeclarations --excludeExternals --mode file index.d.ts main.d.ts renderer.d.ts --out ./typedocs"
+		"generate-typedocs": "typedoc --includeDeclarations --excludeExternals --mode file index.d.ts main.d.ts renderer.d.ts graphql.d.ts --out ./typedocs"
 	},
 	"types": "types.d.ts",
 	"devDependencies": {


### PR DESCRIPTION
## Summary

The github action on this repo is failing when attempting to compile typescript docs due to it not recognizing the graphql module definition.

This fixes that!

Relevant context in this slack thread: https://wpengine.slack.com/archives/C0193JM2UHJ/p1607640524070400