### PR TITLE
chore: bump electron to 37.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"apollo-boost": "^0.1.21",
 		"awilix": "^4.2.5",
 		"cross-fetch": "^3.1.5",
-		"electron": "^v28",
+		"electron": "^37.3.1",
 		"graphql": "^16.8.1",
 		"graphql-subscriptions": "^2.0.0",
 		"graphql-tag": "^2.11.0",


### PR DESCRIPTION
- Syncs with version in Local.
- Uses one of the 'fixed versions' to address https://github.com/getflywheel/local-addon-api/security/dependabot/9.

The electron dep is only used for type info here, so nothing to redeploy.